### PR TITLE
fix issues with patterns stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker build -t mcp/edgedelta -f Dockerfile .
         "ED_ORG_ID",
         "-e",
         "ED_API_TOKEN",
-        "mcp/edgedelta"
+        "ghcr.io/edgedelta/edgedelta-mcp-server:latest"
       ],
       "env": {
         "ED_API_TOKEN": "<YOUR_TOKEN>",

--- a/pkg/core/client.go
+++ b/pkg/core/client.go
@@ -123,3 +123,30 @@ func (c *Client) GetEvents(opts ...QueryParamOption) (*EventResponse, error) {
 	}
 	return &records, nil
 }
+
+func (c *Client) GetPatternStats(opts ...QueryParamOption) (*PatternStatsResponse, error) {
+	url, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/clustering/stats", c.apiBaseURL, c.orgID))
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.createRequest(url, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pattern stats query, err: %v", err)
+	}
+	resp, err := c.cl.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch payload from url: %s, status code %d", req.URL.RequestURI(), resp.StatusCode)
+	}
+
+	records := PatternStatsResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(&records); err != nil {
+		return nil, fmt.Errorf("failed to decode body into json for url: %s, err: %v", req.URL.RequestURI(), err)
+	}
+	return &records, nil
+}

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -40,6 +40,10 @@ type EventResponse struct {
 	NextCursor string       `json:"next_cursor"`
 }
 
+type PatternStatsResponse struct {
+	Stats []*PatternStats `json:"stats"`
+}
+
 type PatternStats struct {
 	// Pattern of the cluster
 	Pattern string `json:"pattern"`

--- a/pkg/core/pattterns.go
+++ b/pkg/core/pattterns.go
@@ -97,7 +97,7 @@ func patternStats(client *Client) (tool mcp.Tool, handler server.ToolHandlerFunc
 				WithSummary(summary),
 			}
 
-			result, err := client.GetLogs(opts...)
+			result, err := client.GetPatternStats(opts...)
 			if err != nil {
 				return nil, fmt.Errorf("failed to search users: %w", err)
 			}


### PR DESCRIPTION
## Summary
Fix patterns stats tool.

## Testing

```
what are the top noisy patterns? I am interested in most noisy ones.

Here are the top 10 noisiest log‑message patterns over the last 15 minutes (ranked by total count):
* DEBUG middleware* Config ID based authentication successful for config * reqID * userID * X Forwarded For * X Host ID *
• count: 701 089 (27.46 % of all logs)
...
```

## Next Steps

Expose pattern details and fleet.