### PR TITLE
[VPB-4212] Add facets and facet options as both resources and tools

### DIFF
--- a/pkg/mcp_server_http/mcp_server_http.go
+++ b/pkg/mcp_server_http/mcp_server_http.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/edgedelta/edgedelta-mcp-server/pkg/swagger2mcp"
+	"github.com/edgedelta/edgedelta-mcp-server/pkg/tools"
 
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -163,6 +164,8 @@ func NewEdgeDeltaMCPHTTPServer(opts ...HTTPServerOption) (*MCPHTTPServer, error)
 	for _, toolToHandler := range toolToHandlers {
 		s.AddTool(toolToHandler.Tool, toolToHandler.Handler)
 	}
+	tools.AddCustomTools(s, httpClient)
+	tools.AddCustomResources(s, httpClient)
 
 	// Create auth middleware that uses the configured header
 	authMiddleware := func(ctx context.Context, r *http.Request) context.Context {

--- a/pkg/mcp_server_stdin/mcp_server_stdin.go
+++ b/pkg/mcp_server_stdin/mcp_server_stdin.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/edgedelta/edgedelta-mcp-server/pkg/swagger2mcp"
+	"github.com/edgedelta/edgedelta-mcp-server/pkg/tools"
 
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -153,6 +154,8 @@ func NewEdgeDeltaMCPStdinServer(apiToken string, opts ...ServerOption) (*MCPServ
 	for _, toolToHandler := range toolToHandlers {
 		s.AddTool(toolToHandler.Tool, toolToHandler.Handler)
 	}
+	tools.AddCustomTools(s, httpClient)
+	tools.AddCustomResources(s, httpClient)
 
 	stdioServer := server.NewStdioServer(s)
 	stdioServer.SetContextFunc(func(ctx context.Context) context.Context {

--- a/pkg/tools/core.go
+++ b/pkg/tools/core.go
@@ -1,7 +1,7 @@
 package tools
 
 import (
-	"context"
+	"net/http"
 	"net/url"
 )
 
@@ -12,12 +12,9 @@ const (
 
 type QueryParamOption func(url.Values)
 
-// Client interface defines the methods for interacting with Edge Delta API
 type Client interface {
-	GetPipelines(ctx context.Context, opts ...QueryParamOption) ([]PipelineSummary, error)
-	SavePipeline(ctx context.Context, confID, description, pipeline, content string) (map[string]interface{}, error)
-	GetFacets(ctx context.Context, opts ...QueryParamOption) ([]Facet, error)
-	GetFacetOptions(ctx context.Context, opts ...QueryParamOption) (*Facet, error)
+	Do(req *http.Request) (*http.Response, error)
+	Get(url string) (*http.Response, error)
 }
 
 // EnvironmentType represents the deployment environment

--- a/pkg/tools/pipelines.go
+++ b/pkg/tools/pipelines.go
@@ -31,7 +31,7 @@ func GetPipelinesTool(client Client) (tool mcp.Tool, handler server.ToolHandlerF
 			if err != nil {
 				return nil, fmt.Errorf("failed to get keyword, err: %w", err)
 			}
-			result, err := client.GetPipelines(ctx, WithLimit(limit), WithKeyword(keyword))
+			result, err := GetPipelines(ctx, client, WithLimit(limit), WithKeyword(keyword))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get pipelines, err: %w", err)
 			}

--- a/pkg/tools/server.go
+++ b/pkg/tools/server.go
@@ -93,7 +93,7 @@ func newServer(spec *OpenAPISpec, apiURL string, allowedTags []string) *Server {
 		tagMap[tag] = struct{}{}
 	}
 
-	httpClient := NewHTTPlient()
+	httpClient := NewHTTPClient()
 	return &Server{
 		allowedTags: tagMap,
 		spec:        spec,
@@ -362,7 +362,7 @@ func (s *Server) addQueryParameters(req *http.Request, parameters []Parameter, r
 
 // FetchSpec fetches and parses the OpenAPI spec from a URL
 func FetchSpec(url string) (*OpenAPISpec, error) {
-	httpClient := NewHTTPlient()
+	httpClient := NewHTTPClient()
 	resp, err := httpClient.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch URL, err: %w", err)
@@ -402,14 +402,21 @@ func CreateServer(version string, spec *OpenAPISpec, apiURL string, allowedTags 
 	}
 
 	// You can add manual tools if you want here.
-	s.AddTool(GetPipelinesTool(srv.client))
-	s.AddTool(FacetsTool, FacetsToolHandler(srv.client))
-	s.AddTool(FacetOptionsTool, FacetOptionsToolHandler(srv.client))
-
-	s.AddResourceTemplate(FacetsResource, FacetsResourceHandler(srv.client))
-	s.AddResourceTemplate(FacetOptionsResource, FacetOptionsResourceHandler(srv.client))
+	AddCustomTools(s, srv.client)
+	AddCustomResources(s, srv.client)
 
 	return s, nil
+}
+
+func AddCustomTools(s *server.MCPServer, client Client) {
+	s.AddTool(GetPipelinesTool(client))
+	s.AddTool(FacetsTool, FacetsToolHandler(client))
+	s.AddTool(FacetOptionsTool, FacetOptionsToolHandler(client))
+}
+
+func AddCustomResources(s *server.MCPServer, client Client) {
+	s.AddResourceTemplate(FacetsResource, FacetsResourceHandler(client))
+	s.AddResourceTemplate(FacetOptionsResource, FacetOptionsResourceHandler(client))
 }
 
 func getDescription(path, method string, operation Operation) string {


### PR DESCRIPTION
## Summary

This would let the LLM query for facets such as service.name. We also have the option in client to pass these resources to LLM as context.

Fixes # [VPB-4212](https://edgedelta.atlassian.net/browse/VPB-4212)
