### PR TITLE
introduce lookbackdays param for get pipelines tool

### DIFF
--- a/pkg/tools/client.go
+++ b/pkg/tools/client.go
@@ -143,6 +143,7 @@ func GetPipelines(ctx context.Context, client Client, lookbackDays int, opts ...
 		}
 	}
 
+	lookbackCutoff := time.Now().UTC().AddDate(0, 0, -lookbackDays)
 	returnPipelines := make([]PipelineSummary, 0)
 	for _, pipeline := range pipelines {
 		if forcedAdd[pipeline.ID] {
@@ -170,7 +171,8 @@ func GetPipelines(ctx context.Context, client Client, lookbackDays int, opts ...
 		}
 
 		// filter out not updated in last lookbackDays days
-		if pipeline.Updated < time.Now().UTC().AddDate(0, 0, -lookbackDays).Format(URLTimeFormat) {
+		updatedTime, err := time.Parse(StorageTimeFormat, pipeline.Updated)
+		if err != nil || updatedTime.IsZero() || updatedTime.Before(lookbackCutoff) {
 			continue
 		}
 

--- a/pkg/tools/core.go
+++ b/pkg/tools/core.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	// URLTimeFormat is used to parse date time query parameters
-	URLTimeFormat = "2006-01-02T15:04:05.000Z"
+	// StorageTimeFormat is used to filter out pipelines that are not updated in the last lookback days
+	StorageTimeFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
 )
 
 type QueryParamOption func(url.Values)

--- a/pkg/tools/pipelines.go
+++ b/pkg/tools/pipelines.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/edgedelta/edgedelta-mcp-server/pkg/params"
 
@@ -44,7 +45,7 @@ func GetPipelinesTool(client Client) (tool mcp.Tool, handler server.ToolHandlerF
 				mcp.Description("Keyword to filter pipelines if provided should be in the pipeline tag"),
 				mcp.DefaultString(""),
 			),
-			mcp.WithNumber("lookback_days",
+			mcp.WithString("lookback_days",
 				mcp.Description("Lookback days to get pipelines, default is 7"),
 				mcp.DefaultNumber(7),
 			),
@@ -59,12 +60,17 @@ func GetPipelinesTool(client Client) (tool mcp.Tool, handler server.ToolHandlerF
 				return nil, fmt.Errorf("failed to get keyword, err: %w", err)
 			}
 
-			lookbackDays, err := params.Optional[int](request, "lookback_days")
-			if err != nil || lookbackDays == 0 {
-				lookbackDays = defaultLookbackDaysForGetPipelines
+			lookbackDays, err := params.Optional[string](request, "lookback_days")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get lookback_days, err: %w", err)
 			}
 
-			result, err := GetPipelines(ctx, client, lookbackDays, WithLimit(limit), WithKeyword(keyword))
+			lookbackDaysVal, ok := getNumber(lookbackDays)
+			if !ok {
+				lookbackDaysVal = defaultLookbackDaysForGetPipelines
+			}
+
+			result, err := GetPipelines(ctx, client, lookbackDaysVal, WithLimit(limit), WithKeyword(keyword))
 			if err != nil {
 				return nil, fmt.Errorf("failed to get pipelines, err: %w", err)
 			}
@@ -76,4 +82,11 @@ func GetPipelinesTool(client Client) (tool mcp.Tool, handler server.ToolHandlerF
 
 			return mcp.NewToolResultText(string(r)), nil
 		}
+}
+
+func getNumber(s string) (int, bool) {
+	if i, err := strconv.Atoi(s); err == nil {
+		return i, true
+	}
+	return 0, false
 }


### PR DESCRIPTION
## Summary

This PR introduces lookbackdays param for get pipelines tool

If it is not provided then it will use 7 days

Fixes # [VPB-5448](https://edgedelta.atlassian.net/browse/VPB-5448)

## Testing

<img width="1376" height="740" alt="Screenshot 2025-08-19 at 00 17 46" src="https://github.com/user-attachments/assets/5da5073e-0189-4481-8e2a-3d53d75a37dd" />

And with lookback_days = "10", tested with the below parameters, and it worked.  Since the results might include sensitive data not to put here.
```
{
  "method": "tools/call",
  "params": {
    "name": "get_pipelines",
    "arguments": {
      "limit": "30",
      "lookback_days": "10"
    }
  }
}
```
