### PR TITLE
feat: Add 4 new graph tools and 2 new resources

### DIFF
--- a/pkg/tools/facet_keys.go
+++ b/pkg/tools/facet_keys.go
@@ -29,6 +29,20 @@ var MetricFacetKeysResource = mcp.NewResource(
 	mcp.WithMIMEType("application/json"),
 )
 
+var TraceFacetKeysResource = mcp.NewResource(
+	"facet-keys://traces",
+	"Trace Facet Keys",
+	mcp.WithResourceDescription("List of available facet keys for traces."),
+	mcp.WithMIMEType("application/json"),
+)
+
+var PatternFacetKeysResource = mcp.NewResource(
+	"facet-keys://patterns",
+	"Pattern Facet Keys",
+	mcp.WithResourceDescription("List of available facet keys for patterns."),
+	mcp.WithMIMEType("application/json"),
+)
+
 var EventFacetKeysResource = mcp.NewResource(
 	"facet-keys://events",
 	"Event Facet Keys",
@@ -119,6 +133,50 @@ func MetricFacetKeysResourceHandler(client Client) server.ResourceHandlerFunc {
 		result, err := json.Marshal(facetKeys)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal metric facet keys: %w", err)
+		}
+
+		return []mcp.ResourceContents{
+			mcp.TextResourceContents{
+				URI:      request.Params.URI,
+				MIMEType: "application/json",
+				Text:     string(result),
+			},
+		}, nil
+	}
+}
+
+func TraceFacetKeysResourceHandler(client Client) server.ResourceHandlerFunc {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		facetKeys, err := GetFacetKeys(ctx, client, "trace")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get trace facet keys: %w", err)
+		}
+
+		result, err := json.Marshal(facetKeys)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal trace facet keys: %w", err)
+		}
+
+		return []mcp.ResourceContents{
+			mcp.TextResourceContents{
+				URI:      request.Params.URI,
+				MIMEType: "application/json",
+				Text:     string(result),
+			},
+		}, nil
+	}
+}
+
+func PatternFacetKeysResourceHandler(client Client) server.ResourceHandlerFunc {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		facetKeys, err := GetFacetKeys(ctx, client, "pattern")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get pattern facet keys: %w", err)
+		}
+
+		result, err := json.Marshal(facetKeys)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal pattern facet keys: %w", err)
 		}
 
 		return []mcp.ResourceContents{

--- a/server/server.go
+++ b/server/server.go
@@ -58,6 +58,10 @@ func AddCustomTools(s *server.MCPServer, client tools.Client) {
 	s.AddTool(tools.GetLogPatternsTool(client))
 	s.AddTool(tools.GetAllDashboardsTool(client))
 	s.AddTool(tools.GetDashboardTool(client))
+	s.AddTool(tools.GetLogGraphTool(client))
+	s.AddTool(tools.GetMetricGraphTool(client))
+	s.AddTool(tools.GetTraceGraphTool(client))
+	s.AddTool(tools.GetPatternGraphTool(client))
 }
 
 func AddCustomResources(s *server.MCPServer, client tools.Client) {
@@ -66,6 +70,8 @@ func AddCustomResources(s *server.MCPServer, client tools.Client) {
 	s.AddResource(tools.ServicesResource, tools.ServicesResourceHandler(client))
 	s.AddResource(tools.LogFacetKeysResource, tools.LogFacetKeysResourceHandler(client))
 	s.AddResource(tools.MetricFacetKeysResource, tools.MetricFacetKeysResourceHandler(client))
+	s.AddResource(tools.TraceFacetKeysResource, tools.TraceFacetKeysResourceHandler(client))
+	s.AddResource(tools.PatternFacetKeysResource, tools.PatternFacetKeysResourceHandler(client))
 	s.AddResource(tools.EventFacetKeysResource, tools.EventFacetKeysResourceHandler(client))
 }
 


### PR DESCRIPTION
## Summary

Add 4 new tools for getting resources in as a timeseries response (for logs, metrics, traces and patterns). Also add 2 new resources for traces and patterns so that these can be utilized while constructing queries.

## Testing

Tested via MCP inspector:
<img width="2225" height="529" alt="Screenshot 2025-10-06 at 15 33 10" src="https://github.com/user-attachments/assets/b3144d15-77df-4391-a2cf-ae6d95e0bdb8" />
<img width="2224" height="504" alt="Screenshot 2025-10-06 at 15 33 15" src="https://github.com/user-attachments/assets/dcf1fb75-8d3e-4f01-a018-31f9b74cc542" />
<img width="1109" height="1075" alt="Screenshot 2025-10-06 at 15 46 42" src="https://github.com/user-attachments/assets/5bff9ed5-3e2b-4d1b-81f9-dc8299a61fb2" />
<img width="1105" height="1070" alt="Screenshot 2025-10-06 at 15 47 02" src="https://github.com/user-attachments/assets/6f71c450-2644-4598-a80b-b6cebc397a81" />
<img width="1155" height="1012" alt="Screenshot 2025-10-06 at 15 49 09" src="https://github.com/user-attachments/assets/6524fca5-f38c-40e2-8a09-6c7057062079" />
<img width="1149" height="1085" alt="Screenshot 2025-10-06 at 15 49 49" src="https://github.com/user-attachments/assets/41f303ce-6863-444a-9672-ed98b6487993" />
<img width="1158" height="1106" alt="Screenshot 2025-10-06 at 15 50 21" src="https://github.com/user-attachments/assets/d6f2c598-bb33-4faa-9cba-ba647e47bc82" />
<img width="1165" height="1116" alt="Screenshot 2025-10-06 at 15 58 57" src="https://github.com/user-attachments/assets/f57cba2a-8352-437b-b812-ac52b3341b89" />
<img width="1169" height="1068" alt="Screenshot 2025-10-06 at 15 59 56" src="https://github.com/user-attachments/assets/02ce030c-5619-440d-9abd-9f42b70f7adf" />
<img width="1150" height="856" alt="Screenshot 2025-10-06 at 16 05 32" src="https://github.com/user-attachments/assets/1c12718f-505b-4f56-bf25-7de5d8484f10" />
<img width="1161" height="942" alt="Screenshot 2025-10-06 at 16 05 59" src="https://github.com/user-attachments/assets/c0a1b333-c83d-4257-826b-f1f5d13d5a69" />
<img width="1165" height="893" alt="Screenshot 2025-10-06 at 16 06 23" src="https://github.com/user-attachments/assets/34c6bd23-3d75-4ea8-823a-e059f0b4587c" />
<img width="1167" height="903" alt="Screenshot 2025-10-06 at 16 06 38" src="https://github.com/user-attachments/assets/1123e7bd-357b-4d39-a715-f5ba5cd5feb4" />
