### PR TITLE
Fix: Handle Formula Response Structure

### DIFF
--- a/pkg/tools/search.go
+++ b/pkg/tools/search.go
@@ -174,6 +174,15 @@ func formatSearchResponse(bodyBytes []byte, query string) (*mcp.CallToolResult, 
 	} else if records, ok := genericResp["records"].([]any); ok {
 		// CommonTimeseriesResponse (metrics graph)
 		totalCount = len(records)
+	} else {
+		// Check for formula-based response structure: {"A": {"records": [...]}}
+		for _, v := range genericResp {
+			if formulaResp, ok := v.(map[string]any); ok {
+				if records, ok := formulaResp["records"].([]any); ok {
+					totalCount += len(records)
+				}
+			}
+		}
 	}
 
 	response := SearchResponse{
@@ -672,6 +681,144 @@ Use discover_schema tool or facet_options tool to verify field values.`),
 			}
 
 			query, _ := params.Optional[string](request, "query")
+			return formatSearchResponse(bodyBytes, query)
+		}
+}
+
+// GetTraceTimelineTool creates a tool to fetch spans suitable for the TraceTimeline component
+func GetTraceTimelineTool(client Client) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("get_trace_timeline",
+			mcp.WithTitleAnnotation("Get Trace Timeline"),
+			mcp.WithDescription(`Fetch spans (OTel) for a timeline view.
+
+IMPORTANT: Call discover_schema tool with scope:"trace" first to see available fields.
+
+CQL Syntax:
+- Field equals: field:"value"
+- Multiple values: field:("val1" OR "val2")
+- Negation: -field:"value"
+
+NOT SUPPORTED for traces:
+- Full-text search (queries without field: prefix) - will cause error
+- Regular expressions (/pattern/)
+
+Common fields: service.name, status.code, span.kind, ed.tag
+
+If empty results: verify field values with facet_options`),
+			mcp.WithString("query",
+				mcp.Description(`CQL filter query (field:value syntax required). Examples:
+- service.name:"api"
+- span.kind:"server"
+- status.code:"ERROR"
+- ed.tag:"prod" AND service.name:("api" OR "web")
+NOTE: Full-text search is NOT supported for traces.`),
+				mcp.DefaultString(""),
+			),
+			mcp.WithString("lookback",
+				mcp.Description("Lookback period in Go duration format (e.g., 1h, 15m, 24h). Provide either lookback or from/to. Pass empty string to use from/to instead."),
+				mcp.DefaultString("1h"),
+			),
+			mcp.WithString("from",
+				mcp.Description("From datetime (ISO 8601: 2006-01-02T15:04:05.000Z). Use with 'to' when not using lookback."),
+				mcp.DefaultString(""),
+			),
+			mcp.WithString("to",
+				mcp.Description("To datetime (ISO 8601: 2006-01-02T15:04:05.000Z). Use with 'from' when not using lookback."),
+				mcp.DefaultString(""),
+			),
+			mcp.WithNumber("limit",
+				mcp.Description("Maximum number of items to return per page (default 20, max 1000)."),
+				mcp.DefaultNumber(20),
+			),
+			mcp.WithString("cursor",
+				mcp.Description("Pagination cursor from a previous response (use next_cursor/previous_cursor)."),
+				mcp.DefaultString(""),
+			),
+			mcp.WithString("order",
+				mcp.Description("Sort order: 'ASC' or 'DESC' (case-insensitive)."),
+				mcp.DefaultString("desc"),
+			),
+			mcp.WithBoolean("include_child_spans",
+				mcp.Description("If true, include child spans for matched spans to provide full trace context."),
+			),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(false),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			orgID, token, err := FetchContextKeys(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			// Build query parameters for traces search
+			tracesURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/traces", client.APIURL(), orgID))
+			if err != nil {
+				return nil, err
+			}
+
+			queryParams := tracesURL.Query()
+			var query string
+			if q, _ := params.Optional[string](request, "query"); q != "" {
+				query = q
+				queryParams.Add("query", query)
+			}
+
+			if lookback, _ := params.Optional[string](request, "lookback"); lookback != "" {
+				queryParams.Add("lookback", lookback)
+			}
+
+			if from, _ := params.Optional[string](request, "from"); from != "" {
+				queryParams.Add("from", from)
+			}
+
+			if to, _ := params.Optional[string](request, "to"); to != "" {
+				queryParams.Add("to", to)
+			}
+
+			if limit, _ := params.Optional[float64](request, "limit"); limit > 0 {
+				queryParams.Add("limit", fmt.Sprintf("%.0f", limit))
+			} else {
+				queryParams.Add("limit", "20")
+			}
+
+			if cursor, _ := params.Optional[string](request, "cursor"); cursor != "" {
+				queryParams.Add("cursor", cursor)
+			}
+
+			if order, _ := params.Optional[string](request, "order"); order != "" {
+				queryParams.Add("order", order)
+			}
+
+			if include, _ := params.Optional[bool](request, "include_child_spans"); include {
+				queryParams.Add("include_child_spans", "true")
+			}
+
+			tracesURL.RawQuery = queryParams.Encode()
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, tracesURL.String(), nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create request: %v", err)
+			}
+
+			req.Header.Add("Content-Type", "application/json")
+			req.Header.Add("X-ED-API-Token", token)
+
+			resp, err := client.Do(req)
+			if err != nil {
+				return nil, err
+			}
+
+			defer resp.Body.Close()
+			bodyBytes, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %v", err)
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				return nil, fmt.Errorf("failed to search traces, status code %d: %s", resp.StatusCode, string(bodyBytes))
+			}
+
 			return formatSearchResponse(bodyBytes, query)
 		}
 }


### PR DESCRIPTION
## Summary

Handle Formula Response Structure and move trace timeline tool under search category tools.

Fixes # (provide jira link which is addressed with this change)
Documents # (provide links to document if any)

## Testing

Formula metric search:
```bash
cat > /tmp/mcp_requests.txt << 'REQUESTS'
{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}
{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_metric_search","arguments":{"metric_name":"ed.pipeline.node.error","aggregation_method":"sum","group_by_keys":["ed.pipeline.node.name","ed.tag"],"lookback":"6h","graph_type":"table","limit":50}}}
REQUESTS

2026/01/08 22:09:05 INFO Starting EdgeDelta MCP Server
2026/01/08 22:09:05 INFO Edge Delta MCP Server running on stdio
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"resources":{},"tools":{"listChanged":true}},"serverInfo":{"name":"edgedelta-mcp-server","version":"0.0.1"}}}
{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"data\":{\"A\":{\"from\":\"2026-01-.....
...
{\"value\":1}}]}},\"total_count\":20,\"query_used\":\"metric:ed.pipeline.node.error filter:*\",\"guidance\":{\"result_status\":\"success\",\"next_steps\":[\"Found 20 results\"]}}"}]}}

```

Formula metric graph:

```bash
cat > /tmp/mcp_requests.txt << 'REQUESTS'
{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}
{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_metric_graph","arguments":{"metric_name":"ed.pipeline.node.error","aggregation_method":"sum","group_by_keys":["ed.pipeline.node.name"],"lookback":"1h","filter_query":"*"}}}
REQUESTS

2026/01/08 22:09:56 INFO Starting EdgeDelta MCP Server
2026/01/08 22:09:56 INFO Edge Delta MCP Server running on stdio
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"resources":{},"tools":{"listChanged":true}},"serverInfo":{"name":"edgedelta-mcp-server","version":"0.0.1"}}}
{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"data\":{\"R1\":{\"from\":\"2026-01-08T18:09:00Z\",\"to\":\"2026-01-08T19:09:00Z\",\"window\":\"1m\",\"keys\":[\"ed.pipeline.node.name\"],\"records\":[
....
[\"kubernetes_input_901c\"],\"timeseries\":[{\"timestamp\":\"2026-01-08T19:01:00Z\",\"value\":1}],\"aggregate\":{\"value\":1}}]}},\"query_used\":\"sum:ed.pipeline.node.error{*} by {ed.pipeline.node.name}\",\"guidance\":{\"result_status\":\"success\",\"next_steps\":[\"Graph data retrieved successfully.\",\"To refine results, adjust filters using facet_options tool to see available values.\"]}}"}]}}
```

Trace timeline:

```bash

cat > /tmp/mcp_requests.txt << 'REQUESTS'
{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}
{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_trace_timeline","arguments":{"query":"service.name:\"admin-api-deployment\"","lookback":"1h","limit":5}}}
REQUESTS

2026/01/08 22:10:20 INFO Starting EdgeDelta MCP Server
2026/01/08 22:10:20 INFO Edge Delta MCP Server running on stdio
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"resources":{},"tools":{"listChanged":true}},"serverInfo":{"name":"edgedelta-mcp-server","version":"0.0.1"}}}
{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"data\":{\"query_id\":\"10c897dd-25c9-4361-90b0-cb1d2464122f\",\"items\":[{\"time_unix_nano\":1767899273389000000,\"trace.id\":\"f9fcd7a2fe233abf846ef2d7ad5aa480\",\"span.id\":\"db342f1.
.....
server\",\"otel.scope.version\":\"0.1.0\"}}],\"next_cursor\":\"JX8DAQEGY3Vyc29yAf-AAAECAQRGcm9tAf-CAAECVG8B_4IAAAAQ_4EFAQEEVGltZQH_ggAAACX_gAEPAQAAAA7g8eoNFr6MdP__AQ8BAAAADuDx94g4JceA__8A\"},\"total_count\":5,\"query_used\":\"service.name:\\\"admin-api-deployment\\\"\",\"guidance\":{\"result_status\":\"success\",\"next_steps\":[\"Found 5 results\"]}}"}]}}


```



## Next Steps

Please describe follow up changes if any.
