### PR TITLE
feat: Add Bearer token support for HTTP server

### DIFF
--- a/pkg/tools/client.go
+++ b/pkg/tools/client.go
@@ -52,15 +52,23 @@ type authedTransport struct {
 }
 
 func (t *authedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if t.apiTokenHeader == "" {
-		return t.Transport.RoundTrip(req)
-	}
-
-	if token, ok := tokenKeyFromContext(req.Context()); ok {
-		req.Header.Set(t.apiTokenHeader, token)
+	ctx := req.Context()
+	if oauthToken, _ := ctx.Value(BearerTokenKey).(string); oauthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+oauthToken)
+	} else if edToken, _ := ctx.Value(EDTokenKey).(string); edToken != "" {
+		req.Header.Set("X-ED-API-Token", edToken)
 	}
 
 	return t.Transport.RoundTrip(req)
+}
+
+// applyAuthHeader sets the appropriate auth header on req. OAuth token takes precedence over ED token.
+func applyAuthHeader(req *http.Request, keys *ContextKeys) {
+	if keys.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+keys.BearerToken)
+	} else if keys.EDToken != "" {
+		req.Header.Set("X-ED-API-Token", keys.EDToken)
+	}
 }
 
 type HTTPClient struct {
@@ -90,17 +98,17 @@ func (c *HTTPClient) APIURL() string {
 }
 
 func GetPipelines(ctx context.Context, client Client, lookbackDays int, opts ...QueryParamOption) ([]PipelineSummary, error) {
-	orgID, token, err := FetchContextKeys(ctx)
+	keys, err := FetchContextKeys(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	pipelineURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/pipelines", client.APIURL(), orgID))
+	pipelineURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/pipelines", client.APIURL(), keys.OrgID))
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := createRequest(ctx, pipelineURL, token)
+	req, err := createRequest(ctx, pipelineURL, keys)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pipelines request, err: %v", err)
 	}
@@ -202,12 +210,12 @@ func GetPipelines(ctx context.Context, client Client, lookbackDays int, opts ...
 }
 
 func SavePipeline(ctx context.Context, client Client, confID, description, pipeline, content string) (map[string]any, error) {
-	orgID, token, err := FetchContextKeys(ctx)
+	keys, err := FetchContextKeys(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	saveURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/pipelines/%s/save", client.APIURL(), orgID, confID))
+	saveURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/pipelines/%s/save", client.APIURL(), keys.OrgID, confID))
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +247,7 @@ func SavePipeline(ctx context.Context, client Client, confID, description, pipel
 	}
 
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-ED-API-Token", token)
+	applyAuthHeader(req, keys)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -261,17 +269,17 @@ func SavePipeline(ctx context.Context, client Client, confID, description, pipel
 }
 
 func GetFacets(ctx context.Context, client Client, opts ...QueryParamOption) ([]Facet, error) {
-	orgID, token, err := FetchContextKeys(ctx)
+	keys, err := FetchContextKeys(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	facetsURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/facets", client.APIURL(), orgID))
+	facetsURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/facets", client.APIURL(), keys.OrgID))
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := createRequest(ctx, facetsURL, token, opts...)
+	req, err := createRequest(ctx, facetsURL, keys, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create facets request: %v", err)
 	}
@@ -300,17 +308,17 @@ func GetFacets(ctx context.Context, client Client, opts ...QueryParamOption) ([]
 }
 
 func GetFacetOptions(ctx context.Context, client Client, opts ...QueryParamOption) (*Facet, error) {
-	orgID, token, err := FetchContextKeys(ctx)
+	keys, err := FetchContextKeys(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	facetURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/facet_options", client.APIURL(), orgID))
+	facetURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/facet_options", client.APIURL(), keys.OrgID))
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := createRequest(ctx, facetURL, token, opts...)
+	req, err := createRequest(ctx, facetURL, keys, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create facet options request: %v", err)
 	}
@@ -334,21 +342,7 @@ func GetFacetOptions(ctx context.Context, client Client, opts ...QueryParamOptio
 	return &facet, nil
 }
 
-func tokenKeyFromContext(ctx context.Context) (string, bool) {
-	value := ctx.Value(TokenKey)
-	if value == nil {
-		return "", false
-	}
-
-	token, ok := value.(string)
-	if !ok {
-		return "", false
-	}
-
-	return token, true
-}
-
-func createRequest(ctx context.Context, reqUrl *url.URL, token string, opts ...QueryParamOption) (*http.Request, error) {
+func createRequest(ctx context.Context, reqUrl *url.URL, keys *ContextKeys, opts ...QueryParamOption) (*http.Request, error) {
 	queryValues := url.Values{}
 	for _, opt := range opts {
 		opt(queryValues)
@@ -361,6 +355,6 @@ func createRequest(ctx context.Context, reqUrl *url.URL, token string, opts ...Q
 	}
 
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-ED-API-Token", token)
+	applyAuthHeader(req, keys)
 	return req, nil
 }

--- a/pkg/tools/context.go
+++ b/pkg/tools/context.go
@@ -9,21 +9,37 @@ import (
 type ContextKey string
 
 const (
-	OrgIDKey  ContextKey = "orgID"
-	TokenKey  ContextKey = "token"
-	APIURLKey ContextKey = "apiURL"
+	OrgIDKey       ContextKey = "orgID"
+	BearerTokenKey ContextKey = "bearerToken"
+	EDTokenKey     ContextKey = "edToken"
+	APIURLKey      ContextKey = "apiURL"
 )
 
-func FetchContextKeys(ctx context.Context) (string, string, error) {
+type ContextKeys struct {
+	OrgID       string
+	EDToken     string
+	BearerToken string
+}
+
+func FetchContextKeys(ctx context.Context) (*ContextKeys, error) {
 	orgID, ok := ctx.Value(OrgIDKey).(string)
 	if !ok {
-		return "", "", fmt.Errorf("orgID not found in context")
+		return nil, fmt.Errorf("orgID not found in context")
 	}
 
-	token, ok := ctx.Value(TokenKey).(string)
-	if !ok {
-		return "", "", fmt.Errorf("token not found in context")
+	var edToken string
+	if val := ctx.Value(EDTokenKey); val != nil {
+		edToken = val.(string)
 	}
 
-	return orgID, token, nil
+	var bearerToken string
+	if val := ctx.Value(BearerTokenKey); val != nil {
+		bearerToken = val.(string)
+	}
+
+	return &ContextKeys{
+		OrgID:       orgID,
+		EDToken:     edToken,
+		BearerToken: bearerToken,
+	}, nil
 }

--- a/pkg/tools/dashboard.go
+++ b/pkg/tools/dashboard.go
@@ -44,12 +44,12 @@ Returns dashboard summaries. Use include_definitions:true for full widget defini
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
 
-			dashboardsURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/dashboards", client.APIURL(), orgID))
+			dashboardsURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/dashboards", client.APIURL(), keys.OrgID))
 			if err != nil {
 				return nil, err
 			}
@@ -66,7 +66,7 @@ Returns dashboard summaries. Use include_definitions:true for full widget defini
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {
@@ -123,7 +123,7 @@ Returns full dashboard configuration including widget definitions and layout.`),
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -133,14 +133,14 @@ Returns full dashboard configuration including widget definitions and layout.`),
 				return mcp.NewToolResultError("missing required parameter: dashboard_id"), err
 			}
 
-			dashboardURL := fmt.Sprintf("%s/v1/orgs/%s/dashboards/%s", client.APIURL(), orgID, dashboardID)
+			dashboardURL := fmt.Sprintf("%s/v1/orgs/%s/dashboards/%s", client.APIURL(), keys.OrgID, dashboardID)
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, dashboardURL, nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create request: %v", err)
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {

--- a/pkg/tools/facet_keys.go
+++ b/pkg/tools/facet_keys.go
@@ -62,13 +62,13 @@ Common fields: event.type, event.domain, service.name, ed.monitor.type.`),
 )
 
 func GetFacetKeys(ctx context.Context, client Client, scope string, opts ...QueryParamOption) ([]FacetKey, error) {
-	orgID, token, err := FetchContextKeys(ctx)
+	keys, err := FetchContextKeys(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// Build the facet_keys API URL
-	facetKeysURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/facet_keys", client.APIURL(), orgID))
+	facetKeysURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/facet_keys", client.APIURL(), keys.OrgID))
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func GetFacetKeys(ctx context.Context, client Client, scope string, opts ...Quer
 	}
 
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-ED-API-Token", token)
+	applyAuthHeader(req, keys)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/tools/graph.go
+++ b/pkg/tools/graph.go
@@ -137,13 +137,13 @@ Use "*" for all logs. Verify fields with discover_schema tool first.`),
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
 
 			// Build query parameters
-			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/graph", client.APIURL(), orgID))
+			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/graph", client.APIURL(), keys.OrgID))
 			if err != nil {
 				return nil, err
 			}
@@ -202,7 +202,7 @@ Use "*" for all logs. Verify fields with discover_schema tool first.`),
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {
@@ -293,13 +293,13 @@ Use "*" for no filter. Verify field values with facet_options.`),
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
 
 			// Build query parameters
-			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/graph", client.APIURL(), orgID))
+			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/graph", client.APIURL(), keys.OrgID))
 			if err != nil {
 				return nil, err
 			}
@@ -390,7 +390,7 @@ Use "*" for no filter. Verify field values with facet_options.`),
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {
@@ -475,13 +475,13 @@ NOTE: Full-text search is NOT supported for traces.`),
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
 
 			// Build query parameters
-			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/graph", client.APIURL(), orgID))
+			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/graph", client.APIURL(), keys.OrgID))
 			if err != nil {
 				return nil, err
 			}
@@ -553,7 +553,7 @@ NOTE: Full-text search is NOT supported for traces.`),
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {
@@ -649,13 +649,13 @@ Use "*" for all patterns. Verify fields with discover_schema tool first.`),
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
 
 			// Build query parameters
-			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/graph", client.APIURL(), orgID))
+			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/graph", client.APIURL(), keys.OrgID))
 			if err != nil {
 				return nil, err
 			}
@@ -744,7 +744,7 @@ Use "*" for all patterns. Verify fields with discover_schema tool first.`),
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {

--- a/pkg/tools/pipelines.go
+++ b/pkg/tools/pipelines.go
@@ -162,7 +162,7 @@ After viewing config, you can:
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -172,14 +172,14 @@ After viewing config, you can:
 				return mcp.NewToolResultError("missing required parameter: conf_id"), err
 			}
 
-			historyURL := fmt.Sprintf("%s/v1/orgs/%s/confs/%s", client.APIURL(), orgID, confID)
+			historyURL := fmt.Sprintf("%s/v1/orgs/%s/confs/%s", client.APIURL(), keys.OrgID, confID)
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, historyURL, nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create request: %w", err)
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {
@@ -243,7 +243,7 @@ Workflow for deployment:
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -253,14 +253,14 @@ Workflow for deployment:
 				return mcp.NewToolResultError("missing required parameter: conf_id"), err
 			}
 
-			historyURL := fmt.Sprintf("%s/v1/orgs/%s/pipelines/%s/history", client.APIURL(), orgID, confID)
+			historyURL := fmt.Sprintf("%s/v1/orgs/%s/pipelines/%s/history", client.APIURL(), keys.OrgID, confID)
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, historyURL, nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create request: %v", err)
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {
@@ -329,7 +329,7 @@ Workflow example:
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -344,14 +344,14 @@ Workflow example:
 				return mcp.NewToolResultError("missing required parameter: version"), err
 			}
 
-			deployURL := fmt.Sprintf("%s/v1/orgs/%s/pipelines/%s/deploy/%s", client.APIURL(), orgID, confID, version)
+			deployURL := fmt.Sprintf("%s/v1/orgs/%s/pipelines/%s/deploy/%s", client.APIURL(), keys.OrgID, confID, version)
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, deployURL, nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create request: %v", err)
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {
@@ -462,7 +462,7 @@ Example node configurations:
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -493,14 +493,14 @@ Example node configurations:
 				return nil, fmt.Errorf("failed to marshal payload: %v", err)
 			}
 
-			addSourceURL := fmt.Sprintf("%s/v1/orgs/%s/pipelines/%s/add_source", client.APIURL(), orgID, confID)
+			addSourceURL := fmt.Sprintf("%s/v1/orgs/%s/pipelines/%s/add_source", client.APIURL(), keys.OrgID, confID)
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, addSourceURL, bytes.NewReader(payloadBytes))
 			if err != nil {
 				return nil, fmt.Errorf("failed to create request: %v", err)
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {

--- a/pkg/tools/search.go
+++ b/pkg/tools/search.go
@@ -86,13 +86,13 @@ Use discover_schema tool or facet_options tool first to verify field names.`),
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
 
 			// Build query parameters
-			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/logs/log_search/search", client.APIURL(), orgID))
+			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/logs/log_search/search", client.APIURL(), keys.OrgID))
 			if err != nil {
 				return nil, err
 			}
@@ -136,7 +136,7 @@ Use discover_schema tool or facet_options tool first to verify field names.`),
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {
@@ -292,13 +292,13 @@ Use "*" for no filter (default). Always verify field values with facet_options f
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
 
 			// Build query parameters
-			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/graph", client.APIURL(), orgID))
+			searchURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/graph", client.APIURL(), keys.OrgID))
 			if err != nil {
 				return nil, err
 			}
@@ -392,7 +392,7 @@ Use "*" for no filter (default). Always verify field values with facet_options f
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {
@@ -476,13 +476,13 @@ Use discover_schema tool or facet_options tool to verify field values.`),
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
 
 			// Build query parameters
-			eventsURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/events/search", client.APIURL(), orgID))
+			eventsURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/events/search", client.APIURL(), keys.OrgID))
 			if err != nil {
 				return nil, err
 			}
@@ -526,7 +526,7 @@ Use discover_schema tool or facet_options tool to verify field values.`),
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {
@@ -610,13 +610,13 @@ Use discover_schema tool or facet_options tool to verify field values.`),
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
 
 			// Build query parameters
-			statsURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/clustering/stats", client.APIURL(), orgID))
+			statsURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/clustering/stats", client.APIURL(), keys.OrgID))
 			if err != nil {
 				return nil, err
 			}
@@ -663,7 +663,7 @@ Use discover_schema tool or facet_options tool to verify field values.`),
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {
@@ -747,13 +747,13 @@ NOTE: Full-text search is NOT supported for traces.`),
 			mcp.WithOpenWorldHintAnnotation(false),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			orgID, token, err := FetchContextKeys(ctx)
+			keys, err := FetchContextKeys(ctx)
 			if err != nil {
 				return nil, err
 			}
 
 			// Build query parameters for traces search
-			tracesURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/traces", client.APIURL(), orgID))
+			tracesURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/traces", client.APIURL(), keys.OrgID))
 			if err != nil {
 				return nil, err
 			}
@@ -802,7 +802,7 @@ NOTE: Full-text search is NOT supported for traces.`),
 			}
 
 			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-ED-API-Token", token)
+			applyAuthHeader(req, keys)
 
 			resp, err := client.Do(req)
 			if err != nil {

--- a/pkg/tools/services.go
+++ b/pkg/tools/services.go
@@ -44,13 +44,13 @@ Services can be used to filter logs, metrics, traces, patterns, and events using
 )
 
 func GetServices(ctx context.Context, client Client, opts ...QueryParamOption) ([]Service, error) {
-	orgID, token, err := FetchContextKeys(ctx)
+	keys, err := FetchContextKeys(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// Build the graph API URL with query parameters
-	graphURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/logs/log_search/graph", client.APIURL(), orgID))
+	graphURL, err := url.Parse(fmt.Sprintf("%s/v1/orgs/%s/logs/log_search/graph", client.APIURL(), keys.OrgID))
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func GetServices(ctx context.Context, client Client, opts ...QueryParamOption) (
 	}
 
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-ED-API-Token", token)
+	applyAuthHeader(req, keys)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/server/http.go
+++ b/server/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/edgedelta/edgedelta-mcp-server/pkg/tools"
 
@@ -57,16 +58,21 @@ func NewHTTPServer(opts ...ServerOption) (*MCPHTTPServer, error) {
 
 	// Create auth middleware that uses the configured header
 	authMiddleware := func(ctx context.Context, r *http.Request) context.Context {
+		// Check for Bearer token in Authorization header
+		if authHeader := r.Header.Get("Authorization"); strings.HasPrefix(authHeader, "Bearer ") {
+			ctx = addToContext(ctx, tools.BearerTokenKey, strings.TrimPrefix(authHeader, "Bearer "))
+		}
+
 		// Check for API token in query parameters
 		apiToken := r.URL.Query().Get("token")
 		if apiToken != "" {
-			ctx = addToContext(ctx, tools.TokenKey, apiToken)
+			ctx = addToContext(ctx, tools.EDTokenKey, apiToken)
 		}
 
 		// Check for API token in headers
 		headerToken := r.Header.Get(config.apiTokenHeader)
 		if headerToken != "" {
-			ctx = addToContext(ctx, tools.TokenKey, headerToken)
+			ctx = addToContext(ctx, tools.EDTokenKey, headerToken)
 		}
 
 		// Check for org ID in path variables

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -47,7 +47,7 @@ func NewStdioServer(orgID, apiToken string, opts ...ServerOption) (*MCPServer, e
 	stdioServer := server.NewStdioServer(s)
 	stdioServer.SetContextFunc(func(ctx context.Context) context.Context {
 		ctx = context.WithValue(ctx, tools.OrgIDKey, orgID)
-		ctx = context.WithValue(ctx, tools.TokenKey, apiToken)
+		ctx = context.WithValue(ctx, tools.EDTokenKey, apiToken)
 		return ctx
 	})
 


### PR DESCRIPTION
## Summary

Add Bearer token support for HTTP server. As a separate authentication mechanism, this will be used for using OAuth initiated tokens during MCP calls.
